### PR TITLE
Rudimentary Markdown support

### DIFF
--- a/Frontend/Helpers/easymde-factory.leaf
+++ b/Frontend/Helpers/easymde-factory.leaf
@@ -1,0 +1,18 @@
+this.fields.forEach( (field, index) => {
+	const textareaID = `textarea${index}`
+	if (field.type === 'Markdown' && this.easyMDE[textareaID] == null) {
+		this.easyMDE[textareaID] = new EasyMDE({
+			element: document.getElementById(textareaID),
+			toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
+				name: 'help',
+				action: 'https://daringfireball.net/projects/markdown/basics',
+				className: 'fa fab fa-question-circle',
+				title: 'Help',
+			}],
+			renderingConfig: {
+				codeSyntaxHighlighting: true
+			},
+			initialValue: field.value.markdown
+		});
+	}
+})

--- a/Frontend/Helpers/fields-markdown-conversion.leaf
+++ b/Frontend/Helpers/fields-markdown-conversion.leaf
@@ -1,0 +1,11 @@
+this.fields.forEach( (field, index) => {
+	const textareaID = `textarea${index}`
+	if (field.type === 'Markdown') {
+		const markdown = this.easyMDE[textareaID].value()
+		const html = this.easyMDE[textareaID].markdown( markdown )
+		field.value = {
+			'markdown': markdown,
+			'html': html
+		}
+	}
+})

--- a/Frontend/Posts/create-post.leaf
+++ b/Frontend/Posts/create-post.leaf
@@ -60,7 +60,12 @@
 				this.fields.forEach( (field, index) => {
 					const textareaID = `textarea${index}`
 					if (field.type === 'Markdown') {
-						field.value = this.easyMDE[textareaID].value()
+						const markdown = this.easyMDE[textareaID].value()
+						const html = this.easyMDE[textareaID].markdown( markdown )
+						field.value = {
+							'markdown': markdown,
+							'html': html
+						}
 					}
 				})
 

--- a/Frontend/Posts/create-post.leaf
+++ b/Frontend/Posts/create-post.leaf
@@ -31,29 +31,7 @@
 			easyMDE: {}
 		},
 		mounted: function() {
-			this.fields.forEach( (field, index) => {
-				const textareaID = `textarea${index}`
-				if (field.type === 'Markdown' && this.easyMDE[textareaID] == null) {
-					this.easyMDE[textareaID] = new EasyMDE({
-						element: document.getElementById(textareaID),
-						toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
-							name: 'help',
-							action: 'https://daringfireball.net/projects/markdown/basics',
-							className: 'fa fab fa-question-circle',
-							title: 'Help',
-						}],
-						autosave: {
-								enabled: true,
-								delay: 1000,
-								uniqueId: `mde-post-autosave-${index}` // TODO: unique id to this specific post
-						},
-						renderingConfig: {
-							codeSyntaxHighlighting: true
-						},
-						initialValue: field.value.markdown
-					});
-				}
-			})
+			#embed("Helpers/easymde-factory")
 		},
 		methods: {
 			createItem: function() {

--- a/Frontend/Posts/create-post.leaf
+++ b/Frontend/Posts/create-post.leaf
@@ -42,11 +42,6 @@
 							className: 'fa fab fa-question-circle',
 							title: 'Help',
 						}],
-						autosave: {
-								enabled: true,
-								delay: 1000,
-								uniqueId: `mde-post-autosave-${index}` // TODO: unique id to this specific post
-						},
 						renderingConfig: {
 							codeSyntaxHighlighting: true
 						},
@@ -57,17 +52,7 @@
 		},
 		methods: {
 			createItem: function() {
-				this.fields.forEach( (field, index) => {
-					const textareaID = `textarea${index}`
-					if (field.type === 'Markdown') {
-						const markdown = this.easyMDE[textareaID].value()
-						const html = this.easyMDE[textareaID].markdown( markdown )
-						field.value = {
-							'markdown': markdown,
-							'html': html
-						}
-					}
-				})
+				#embed("Helpers/fields-markdown-conversion")
 
 				return {
 					categoryID: #js(category.id),

--- a/Frontend/Posts/create-post.leaf
+++ b/Frontend/Posts/create-post.leaf
@@ -27,10 +27,43 @@
 				}
 			],
 			authors: null,
-			errors: []
+			errors: [],
+			easyMDE: {}
+		},
+		mounted: function() {
+			this.fields.forEach( (field, index) => {
+				const textareaID = `textarea${index}`
+				if (field.type === 'Markdown' && this.easyMDE[textareaID] == null) {
+					this.easyMDE[textareaID] = new EasyMDE({
+						element: document.getElementById(textareaID),
+						toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
+							name: 'help',
+							action: 'https://daringfireball.net/projects/markdown/basics',
+							className: 'fa fab fa-question-circle',
+							title: 'Help',
+						}],
+						autosave: {
+								enabled: true,
+								delay: 1000,
+								uniqueId: `mde-post-autosave-${index}` // TODO: unique id to this specific post
+						},
+						renderingConfig: {
+							codeSyntaxHighlighting: true
+						},
+						initialValue: field.value
+					});
+				}
+			})
 		},
 		methods: {
 			createItem: function() {
+				this.fields.forEach( (field, index) => {
+					const textareaID = `textarea${index}`
+					if (field.type === 'Markdown') {
+						field.value = this.easyMDE[textareaID].value()
+					}
+				})
+
 				return {
 					categoryID: #js(category.id),
 					authors: [],

--- a/Frontend/Posts/create-post.leaf
+++ b/Frontend/Posts/create-post.leaf
@@ -42,10 +42,15 @@
 							className: 'fa fab fa-question-circle',
 							title: 'Help',
 						}],
+						autosave: {
+								enabled: true,
+								delay: 1000,
+								uniqueId: `mde-post-autosave-${index}` // TODO: unique id to this specific post
+						},
 						renderingConfig: {
 							codeSyntaxHighlighting: true
 						},
-						initialValue: field.value
+						initialValue: field.value.markdown
 					});
 				}
 			})

--- a/Frontend/Posts/edit-post.leaf
+++ b/Frontend/Posts/edit-post.leaf
@@ -74,6 +74,8 @@
 		},
 		methods: {
 			createItem: function() {
+				#embed("Helpers/fields-markdown-conversion")
+
 				return {
 					id: #js(post.id),
 					categoryID: #js(post.categoryID),

--- a/Frontend/Posts/edit-post.leaf
+++ b/Frontend/Posts/edit-post.leaf
@@ -70,7 +70,11 @@
 				}
 			],
 			modifiedAuthors: [],
-			errors: []
+			errors: [],
+			easyMDE: {}
+		},
+		mounted: function() {
+			#embed("Helpers/easymde-factory")
 		},
 		methods: {
 			createItem: function() {

--- a/Frontend/Posts/post-fields.leaf
+++ b/Frontend/Posts/post-fields.leaf
@@ -1,4 +1,11 @@
 #embed("errors")
+
+<link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+<script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+<link rel="stylesheet"
+      href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/default.min.css">
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+
 <form
 	v-on:submit.prevent="handleSubmit"
 >
@@ -26,7 +33,7 @@
 	</td>
 	<!-- TODO: remove / add buttons, or edit button w/ modal -->
 </tr>
-<tr v-cloak v-for="field in fields">
+<tr v-cloak v-for="(field, index) in fields">
 	<td>
 		<b class="field-label" v-text="field.name"></b>
 	</td>
@@ -37,6 +44,12 @@
 			v-model="field.value"
 			:required="field.required ? true : false"
 		/>
+		<textarea
+			v-if="field.type == 'Markdown'"
+			v-model="field.value"
+			v-bind:id=`textarea${index}`
+		>
+		</textarea>
 		<label v-if="field.type == 'Bool'">
 			<input
 				type="checkbox"

--- a/Frontend/Posts/post-fields.leaf
+++ b/Frontend/Posts/post-fields.leaf
@@ -46,7 +46,6 @@
 		/>
 		<textarea
 			v-if="field.type == 'Markdown'"
-			v-model="field.value"
 			v-bind:id=`textarea${index}`
 		>
 		</textarea>

--- a/Frontend/Types/create-type.leaf
+++ b/Frontend/Types/create-type.leaf
@@ -20,7 +20,14 @@ var create = new Vue({
 		name: null,
 		plural: null,
 		fields: [],
-		errors: []
+		errors: [],
+		easyMDE: null
+	},
+	updated: function() {
+		this.easyMDE = new EasyMDE({
+				autofocus: true,
+		    initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
+			});
 	},
 	methods: {
 		addField: function(type) {

--- a/Frontend/Types/create-type.leaf
+++ b/Frontend/Types/create-type.leaf
@@ -36,11 +36,15 @@ var create = new Vue({
 						className: 'fa fab fa-question-circle',
 						title: 'Help',
 					}],
+					forceSync: true,
 					autosave: {
-	            enabled: true,
-	            delay: 1000,
-	            uniqueId: `mde-autosave-${index}`
-	        }
+							enabled: true,
+							delay: 1000,
+							uniqueId: `mde-type-autosave-${index}`
+					},
+					renderingConfig: {
+						codeSyntaxHighlighting: true
+					},
 				});
 			}
 		})

--- a/Frontend/Types/create-type.leaf
+++ b/Frontend/Types/create-type.leaf
@@ -25,8 +25,14 @@ var create = new Vue({
 	},
 	updated: function() {
 		this.easyMDE = new EasyMDE({
+				toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
+					name: 'help',
+					action: 'https://daringfireball.net/projects/markdown/basics',
+					className: 'fa fab fa-question',
+					title: 'Help',
+				}],
 				autofocus: true,
-		    initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
+				initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
 			});
 	},
 	methods: {

--- a/Frontend/Types/create-type.leaf
+++ b/Frontend/Types/create-type.leaf
@@ -24,28 +24,7 @@ var create = new Vue({
 		easyMDE: {}
 	},
 	updated: function() {
-		this.fields.forEach( (field, index) => {
-			const textareaID = `textarea${index}`
-			if (field.type === 'Markdown' && this.easyMDE[textareaID] == null) {
-				this.easyMDE[textareaID] = new EasyMDE({
-					element: document.getElementById(textareaID),
-					toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
-						name: 'help',
-						action: 'https://daringfireball.net/projects/markdown/basics',
-						className: 'fa fab fa-question-circle',
-						title: 'Help',
-					}],
-					autosave: {
-							enabled: true,
-							delay: 1000,
-							uniqueId: `mde-type-autosave-${index}`
-					},
-					renderingConfig: {
-						codeSyntaxHighlighting: true
-					}
-				});
-			}
-		})
+		#embed("Helpers/easymde-factory")
 	},
 	methods: {
 		addField: function(type) {

--- a/Frontend/Types/create-type.leaf
+++ b/Frontend/Types/create-type.leaf
@@ -21,19 +21,29 @@ var create = new Vue({
 		plural: null,
 		fields: [],
 		errors: [],
-		easyMDE: null
+		easyMDE: {}
 	},
 	updated: function() {
-		this.easyMDE = new EasyMDE({
-				toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
-					name: 'help',
-					action: 'https://daringfireball.net/projects/markdown/basics',
-					className: 'fa fab fa-question',
-					title: 'Help',
-				}],
-				autofocus: true,
-				initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
-			});
+		this.fields.forEach( (field, index) => {
+			const textareaID = `textarea${index}`
+			if (field.type === 'Markdown' && this.easyMDE[textareaID] == null) {
+				console.log(textareaID)
+				this.easyMDE[textareaID] = new EasyMDE({
+					element: document.getElementById(textareaID),
+					toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
+						name: 'help',
+						action: 'https://daringfireball.net/projects/markdown/basics',
+						className: 'fa fab fa-question-circle',
+						title: 'Help',
+					}],
+					autosave: {
+	            enabled: true,
+	            delay: 1000,
+	            uniqueId: `mde-autosave-${index}`
+	        }
+				});
+			}
+		})
 	},
 	methods: {
 		addField: function(type) {

--- a/Frontend/Types/create-type.leaf
+++ b/Frontend/Types/create-type.leaf
@@ -27,7 +27,6 @@ var create = new Vue({
 		this.fields.forEach( (field, index) => {
 			const textareaID = `textarea${index}`
 			if (field.type === 'Markdown' && this.easyMDE[textareaID] == null) {
-				console.log(textareaID)
 				this.easyMDE[textareaID] = new EasyMDE({
 					element: document.getElementById(textareaID),
 					toolbar: ['bold', 'italic', 'strikethrough', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'image', 'horizontal-rule', '|', 'preview', '|', 'redo', 'undo', '|', {
@@ -36,7 +35,6 @@ var create = new Vue({
 						className: 'fa fab fa-question-circle',
 						title: 'Help',
 					}],
-					forceSync: true,
 					autosave: {
 							enabled: true,
 							delay: 1000,
@@ -44,7 +42,7 @@ var create = new Vue({
 					},
 					renderingConfig: {
 						codeSyntaxHighlighting: true
-					},
+					}
 				});
 			}
 		})
@@ -62,6 +60,8 @@ var create = new Vue({
 			this.fields.splice( this.fields.indexOf(field), 1 )
 		},
 		createCategory: function() {
+			#embed("Helpers/fields-markdown-conversion")
+
 			return {
 				name: this.name,
 				plural: (this.plural || this.name + 's'),

--- a/Frontend/Types/edit-type.leaf
+++ b/Frontend/Types/edit-type.leaf
@@ -41,6 +41,8 @@
 				this.fields.splice( this.fields.indexOf(field), 1 )
 			},
 			createCategory: function() {
+				#embed("Helpers/fields-markdown-conversion")
+
 				return {
 					name: this.name,
 					plural: (this.plural || this.name + 's'),

--- a/Frontend/Types/edit-type.leaf
+++ b/Frontend/Types/edit-type.leaf
@@ -26,7 +26,14 @@
 					\},
 				}
 			],
-			errors: []
+			errors: [],
+			easyMDE: {}
+		},
+		mounted: function() {
+			#embed("Helpers/easymde-factory")
+		},
+		updated: function() {
+			#embed("Helpers/easymde-factory")
 		},
 		methods: {
 			addField: function(type) {

--- a/Frontend/Types/type-fields.leaf
+++ b/Frontend/Types/type-fields.leaf
@@ -1,16 +1,7 @@
 #embed("errors")
 
-<link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
-<script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
-
-<textarea>
-</textarea>
-<script>
-	var easyMDE = new EasyMDE({
-		autofocus: true,
-    initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
-	});
-</script>
+<link v-pre rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+<script v-pre src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 
 <form
 	v-on:submit.prevent="handleSubmit"
@@ -75,6 +66,7 @@
 		/>
 		<textarea
 			v-if="field.type == 'Markdown'"
+			v-model="field.value"
 		>
 		</textarea>
 <!-- 		<script>

--- a/Frontend/Types/type-fields.leaf
+++ b/Frontend/Types/type-fields.leaf
@@ -1,7 +1,7 @@
 #embed("errors")
 
-<link v-pre rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
-<script v-pre src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+<script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 
 <form
 	v-on:submit.prevent="handleSubmit"

--- a/Frontend/Types/type-fields.leaf
+++ b/Frontend/Types/type-fields.leaf
@@ -66,7 +66,6 @@
 		/>
 		<textarea
 			v-if="field.type == 'Markdown'"
-			v-model="field.value"
 			v-bind:id=`textarea${index}`
 		>
 		</textarea>

--- a/Frontend/Types/type-fields.leaf
+++ b/Frontend/Types/type-fields.leaf
@@ -45,7 +45,7 @@
 		<td><input type="text" disabled class="placeholder"></input></td>
 		<td><label><input type="checkbox" disabled class="placeholder"><span></span></label></span></td>
 	</tr>
-	<tr v-cloak v-for="field in fields">
+	<tr v-cloak v-for="(field, index) in fields">
 		<td>
 			<b class="field-label" v-text="field.type"></b>
 		</td>
@@ -67,14 +67,9 @@
 		<textarea
 			v-if="field.type == 'Markdown'"
 			v-model="field.value"
+			v-bind:id=`textarea${index}`
 		>
 		</textarea>
-<!-- 		<script>
-			var easyMDE = new EasyMDE({
-				autofocus: true,
-        initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
-			});
-		</script> -->
 		<label v-if="field.type == 'Bool'">
 			<input
 				type="checkbox"

--- a/Frontend/Types/type-fields.leaf
+++ b/Frontend/Types/type-fields.leaf
@@ -1,4 +1,17 @@
 #embed("errors")
+
+<link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+<script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+
+<textarea>
+</textarea>
+<script>
+	var easyMDE = new EasyMDE({
+		autofocus: true,
+    initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
+	});
+</script>
+
 <form
 	v-on:submit.prevent="handleSubmit"
 >
@@ -60,6 +73,16 @@
 			v-model="field.value"
 			placeholder="Default value"
 		/>
+		<textarea
+			v-if="field.type == 'Markdown'"
+		>
+		</textarea>
+<!-- 		<script>
+			var easyMDE = new EasyMDE({
+				autofocus: true,
+        initialValue: '# EasyMDE \n Go ahead, play around with the editor! Be sure to check out **bold**, *italic* and ~~strikethrough~~ styling, [links](https://google.com) and all the other features. You can type the Markdown syntax, use the toolbar, or use shortcuts like `ctrl-b` or `cmd-b`.'
+			});
+		</script> -->
 		<label v-if="field.type == 'Bool'">
 			<input
 				type="checkbox"
@@ -93,6 +116,7 @@
 </form>
 <div class="add-field">
 	<button v-on:click="addField('String')">Text</button>
+	<button v-on:click="addField('Markdown')">Rich text</button>
 	<button v-on:click="addField('Date')">Date</button>
 	<button v-on:click="addField('URL')">Link</button>
 	<button v-on:click="addField('Bool')">Switch</button>

--- a/Public/styles/style.css
+++ b/Public/styles/style.css
@@ -111,6 +111,10 @@ td:not(:first-child) {
 	text-align: center;
 }
 
+td div {
+  text-align: left;
+}
+
 td, th, div.field {
 	padding: 0.25rem 0.4rem;
 }
@@ -351,6 +355,9 @@ button.remove {
 	height: 28px;
 	background-size: 28px 28px;
 	background-color: transparent;
+}
+.editor-toolbar button {
+	color: #1E1E21;
 }
 .author button.remove {
 	margin-left: 0.5rem;

--- a/Sources/App/Controllers/GraphQLController.swift
+++ b/Sources/App/Controllers/GraphQLController.swift
@@ -36,7 +36,8 @@ private extension GraphQLController {
             let schema = try GraphQLSchema(
                 query: GraphQLObjectType(
                     name: "RootQueryType",
-                    fields: rootFields)
+                    fields: rootFields),
+                types: SupportedType.graphQLNamedTypes
             )
             return schema
         }

--- a/Sources/App/Leaf/JSEscapedFormat.swift
+++ b/Sources/App/Leaf/JSEscapedFormat.swift
@@ -14,17 +14,32 @@ public final class JSEscapedFormat: TagRenderer {
             enclosingQuotes = false
         }
 
-        guard var escaped = tag.parameters.first?.string?.replacingOccurrences(of: "'", with: "\\'") else {
-            return tag.container.future(TemplateData.string("''"))
+        if let object = tag.parameters.first?.dictionary {
+            var objectString = "{"
+            for (key, value) in object {
+                objectString.append("""
+                    \(escape(string: key, enclosingQuotes: true)): \(escape(string: value.string ?? "null", enclosingQuotes: true)),
+                  """)
+            }
+            objectString.append(" }")
+            return tag.container.future(TemplateData.string(objectString))
         }
 
-        escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
+        guard let string = tag.parameters.first?.string else { return tag.container.future(TemplateData.string("''")) }
+
+        return tag.container.future(TemplateData.string(escape(string: string, enclosingQuotes: enclosingQuotes)))
+    }
+
+    private func escape(string: String, enclosingQuotes: Bool) -> String {
+        var string = string
+        string = string.replacingOccurrences(of: "'", with: "\\'")
+        string = string.replacingOccurrences(of: "\n", with: "\\n")
 
         if enclosingQuotes {
-            escaped = "'\(escaped)'"
+            string = "'\(string)'"
         }
 
-        return tag.container.future(TemplateData.string(escaped))
+        return string
     }
 
 }

--- a/Sources/App/Leaf/JSEscapedFormat.swift
+++ b/Sources/App/Leaf/JSEscapedFormat.swift
@@ -18,6 +18,8 @@ public final class JSEscapedFormat: TagRenderer {
             return tag.container.future(TemplateData.string("''"))
         }
 
+        escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
+
         if enclosingQuotes {
             escaped = "'\(escaped)'"
         }

--- a/Sources/App/Models/ContentField.swift
+++ b/Sources/App/Models/ContentField.swift
@@ -12,7 +12,8 @@ struct ContentField: Content {
         type = try container.decode(SupportedType.self, forKey: .type)
         required = try container.decode(Bool.self, forKey: .required)
         switch type {
-        case .string, .markdown: value = SupportedValue.string(try? container.decode(String.self, forKey: .value))
+        case .markdown: value = SupportedValue.markdown(try? container.decode(Markdown.self, forKey: .value))
+        case .string: value = SupportedValue.string(try? container.decode(String.self, forKey: .value))
         case .int: value = SupportedValue.int(try? container.decode(Int.self, forKey: .value))
         case .float: value = SupportedValue.float(try? container.decode(Float.self, forKey: .value))
         case .bool: value = SupportedValue.bool(try? container.decode(Bool.self, forKey: .value))

--- a/Sources/App/Models/ContentField.swift
+++ b/Sources/App/Models/ContentField.swift
@@ -12,7 +12,7 @@ struct ContentField: Content {
         type = try container.decode(SupportedType.self, forKey: .type)
         required = try container.decode(Bool.self, forKey: .required)
         switch type {
-        case .string: value = SupportedValue.string(try? container.decode(String.self, forKey: .value))
+        case .string, .markdown: value = SupportedValue.string(try? container.decode(String.self, forKey: .value))
         case .int: value = SupportedValue.int(try? container.decode(Int.self, forKey: .value))
         case .float: value = SupportedValue.float(try? container.decode(Float.self, forKey: .value))
         case .bool: value = SupportedValue.bool(try? container.decode(Bool.self, forKey: .value))

--- a/Sources/App/Models/GraphQLTypes.swift
+++ b/Sources/App/Models/GraphQLTypes.swift
@@ -16,6 +16,14 @@ extension SupportedType {
         }
     }
 
+    static var graphQLNamedTypes: [GraphQLNamedType] {
+        var types = [GraphQLNamedType]()
+        if let markdown = SupportedType.markdown.graphQL as? GraphQLNamedType {
+            types.append(markdown)
+        }
+        return types
+    }
+
     private static var graphQLMarkdownType: GraphQLOutputType {
         let fields = [
             "html": GraphQLField(type: GraphQLString, resolve: { (source, args, context, eventLoopGroup, info) -> EventLoopFuture<Any?> in

--- a/Sources/App/Models/GraphQLTypes.swift
+++ b/Sources/App/Models/GraphQLTypes.swift
@@ -1,9 +1,11 @@
+import Vapor
 import GraphQL
 
 extension SupportedType {
     var graphQL: GraphQLOutputType {
         switch self {
-        case .string, .markdown: return GraphQLString
+        case .markdown: return SupportedType.graphQLMarkdownType
+        case .string: return GraphQLString
         case .int: return GraphQLInt
         case .float: return GraphQLFloat
         case .bool: return GraphQLBoolean
@@ -13,6 +15,24 @@ extension SupportedType {
             return GraphQLList(type.graphQL)
         }
     }
+
+    private static var graphQLMarkdownType: GraphQLOutputType {
+        let fields = [
+            "html": GraphQLField(type: GraphQLString, resolve: { (source, args, context, eventLoopGroup, info) -> EventLoopFuture<Any?> in
+                guard let markdown = source as? Markdown else {
+                    return eventLoopGroup.future(nil)
+                }
+                return eventLoopGroup.future(markdown.html)
+            }),
+            "markdown": GraphQLField(type: GraphQLString, resolve: { (source, args, context, eventLoopGroup, info) -> EventLoopFuture<Any?> in
+                guard let markdown = source as? Markdown else {
+                    return eventLoopGroup.future(nil)
+                }
+                return eventLoopGroup.future(markdown.markdown)
+            })]
+        return try! GraphQLObjectType(name: "Markdown",
+                                      fields: fields)
+    }
 }
 
 extension SupportedValue {
@@ -20,6 +40,7 @@ extension SupportedValue {
         switch self {
         case .string(let value): return value as Any
         case .bool(let value): return value as Any
+        case .markdown(let value): return value as Any
         default:
             fatalError()
         }

--- a/Sources/App/Models/GraphQLTypes.swift
+++ b/Sources/App/Models/GraphQLTypes.swift
@@ -3,7 +3,7 @@ import GraphQL
 extension SupportedType {
     var graphQL: GraphQLOutputType {
         switch self {
-        case .string: return GraphQLString
+        case .string, .markdown: return GraphQLString
         case .int: return GraphQLInt
         case .float: return GraphQLFloat
         case .bool: return GraphQLBoolean

--- a/Sources/App/Models/Markdown.swift
+++ b/Sources/App/Models/Markdown.swift
@@ -1,0 +1,6 @@
+import Vapor
+
+struct Markdown: Content, Equatable {
+    var markdown: String
+    var html: String
+}

--- a/Sources/App/Models/SupportedType.swift
+++ b/Sources/App/Models/SupportedType.swift
@@ -6,6 +6,7 @@ enum SupportedType: Content, ReflectionDecodable, Equatable, RawRepresentable {
     typealias RawValue = String
 
     case string
+    case markdown
     case int
     case float
     case bool
@@ -16,6 +17,7 @@ enum SupportedType: Content, ReflectionDecodable, Equatable, RawRepresentable {
     init?(rawValue: RawValue) {
         switch rawValue {
         case "String": self = .string
+        case "Markdown": self = .markdown
         case "Int": self = .int
         case "Float": self = .float
         case "Bool": self = .bool
@@ -46,6 +48,7 @@ enum SupportedType: Content, ReflectionDecodable, Equatable, RawRepresentable {
     var rawValue: RawValue {
         switch self {
         case .string: return "String"
+        case .markdown: return "Markdown"
         case .int: return "Int"
         case .float: return "Float"
         case .bool: return "Bool"

--- a/Sources/App/Models/SupportedValue.swift
+++ b/Sources/App/Models/SupportedValue.swift
@@ -2,6 +2,7 @@ import Vapor
 import Foundation
 
 enum SupportedValue: Content, Equatable, TemplateDataRepresentable {
+    case markdown(Markdown?)
     case string(String?)
     case int(Int?)
     case float(Float?)
@@ -12,6 +13,10 @@ enum SupportedValue: Content, Equatable, TemplateDataRepresentable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
+        do {
+            self = .markdown(try container.decode(Markdown.self))
+            return
+        } catch { }
         do {
             self = .date(try container.decode(Date.self))
             return
@@ -46,6 +51,7 @@ enum SupportedValue: Content, Equatable, TemplateDataRepresentable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .markdown(let markdown): try container.encode(markdown)
         case .string(let string): try container.encode(string)
         case .int(let int): try container.encode(int)
         case .float(let float): try container.encode(float)
@@ -58,6 +64,12 @@ enum SupportedValue: Content, Equatable, TemplateDataRepresentable {
 
     func convertToTemplateData() throws -> TemplateData {
         switch self {
+        case .markdown(let markdown):
+            guard let markdown = markdown else {
+                return TemplateData.null
+            }
+            return TemplateData.dictionary(["markdown": TemplateData.string(markdown.markdown),
+                                            "html": TemplateData.string(markdown.html)])
         case .string(let string):
             guard let string = string else {
                 return TemplateData.null


### PR DESCRIPTION
Closes #16 

Using [EasyMDE](https://github.com/Ionaru/easy-markdown-editor) as a nice inline Markdown editor. Created a new `Markdown` content type that contains both Markdown text and rendered HTML.

The styles for the editor are still rough, but I'm planning a big restyling PR once more types are implemented